### PR TITLE
Initial Sidekiq Setup + Instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'rgeo'
 gem 'rgeo-geojson'
 gem 'active_model_serializers'
+gem 'sidekiq'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    connection_pool (2.2.1)
     crass (1.0.3)
     erubi (1.7.0)
     execjs (2.7.0)
@@ -137,6 +138,8 @@ GEM
     public_suffix (3.0.2)
     puma (3.11.2)
     rack (2.0.4)
+    rack-protection (2.0.1)
+      rack
     rack-proxy (0.6.4)
       rack
     rack-test (0.8.3)
@@ -168,6 +171,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redis (4.0.1)
     rgeo (1.0.0)
     rgeo-activerecord (6.0.0)
       activerecord (~> 5.0)
@@ -190,6 +194,11 @@ GEM
     selenium-webdriver (3.10.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2)
+    sidekiq (5.1.3)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -256,6 +265,7 @@ DEPENDENCIES
   rgeo-geojson
   sass-rails (~> 5.0)
   selenium-webdriver
+  sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,63 @@ From the State of Massachusetts Efficiency and Regionalization Grant Program pro
 
 ## Setup and Installation
 
-TODO
+You will need to setup Sidekiq on your server for running background jobs. To do this on an Ubuntu server you should first install redis with `sudo apt-get install redis-server`.
+
+Put the following file into `/lib/systemd/system/sidekiq-roadworks.service`:
+
+```
+#
+# systemd unit file for CentOS 7, Ubuntu 15.04
+#
+# Customize this file based on your bundler location, app directory, etc.
+# Put this in /usr/lib/systemd/system (CentOS) or /lib/systemd/system (Ubuntu).
+# Run:
+#   - systemctl enable sidekiq
+#   - systemctl {start,stop,restart} sidekiq
+#
+# This file corresponds to a single Sidekiq process.  Add multiple copies
+# to run multiple processes (sidekiq-1, sidekiq-2, etc).
+#
+# See Inspeqtor's Systemd wiki page for more detail about Systemd:
+# https://github.com/mperham/inspeqtor/wiki/Systemd
+#
+[Unit]
+Description=sidekiq
+# start us only once the network and logging subsystems are available,
+# consider adding redis-server.service if Redis is local and systemd-managed.
+After=syslog.target network.target
+
+# See these pages for lots of options:
+# http://0pointer.de/public/systemd-man/systemd.service.html
+# http://0pointer.de/public/systemd-man/systemd.exec.html
+[Service]
+Type=simple
+WorkingDirectory=/var/www/roadworks/current
+# If you use rbenv:
+# ExecStart=/bin/bash -lc 'bundle exec sidekiq -e production'
+# If you use the system's ruby:
+ExecStart=/home/roadworks/.rvm/wrappers/default/bundle exec sidekiq -e staging
+User=roadworks
+Group=roadworks
+UMask=0002
+
+# if we crash, restart
+RestartSec=1
+Restart=on-failure
+
+# output goes to /var/log/syslog
+StandardOutput=syslog
+StandardError=syslog
+
+# This will default to "bundler" if we don't specify it
+SyslogIdentifier=roadworks
+
+[Install]
+WantedBy=multi-user.target
+```
+Then to enable this run: `sudo systemctl enable sidekiq-roadworks`
+
+In development you will need to run sidekiq with `bundle exec sidekiq`.
 
 ## Testing
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module MyApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
+    config.active_job.queue_adapter = :sidekiq
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
This is the initial setup of the Sidekiq. It sets ActiveJob to use sidekiq for background processing and includes instructions for provisioning a server with Sidekiq.