### PR TITLE
Enforce chronology between groups of MonthYearField components

### DIFF
--- a/app/assets/javascript/app/components/fields/MonthYearField.jsx
+++ b/app/assets/javascript/app/components/fields/MonthYearField.jsx
@@ -33,22 +33,21 @@ class MonthYearField extends React.Component {
 
     this.onMonthChange = this.onMonthChange.bind(this);
     this.onYearChange = this.onYearChange.bind(this);
-    this.setTimeConstraints = this.setTimeConstraints.bind(this);
   }
 
-  setTimeConstraints() {
+  componentWillUpdate(nextProps, nextState) {
     const intOrNull = x => (x && x !== 'NONE') ? parseInt(x) : null;
-    const selectedYear = intOrNull(this.state.year);
-    const selectedMonth = intOrNull(this.state.month);
+    const selectedYear = intOrNull(nextState.year);
+    const selectedMonth = intOrNull(nextState.month);
 
     let startMonth = 0;
     let endMonth = monthPool.length;
-    let startYear = this.props.startYear || (new Date()).getFullYear();
-    let range = this.props.range || 25;
+    let startYear = nextProps.startYear || (new Date()).getFullYear();
+    let range = nextProps.range || 25;
     let startYearMod = 0;
 
-    if (this.props.predate) {
-      const predate = new Date(this.props.predate);
+    if (nextProps.predate) {
+      const predate = new Date(nextProps.predate);
       const predateYear = predate.getFullYear()
       const predateMonth = predate.getMonth();
 
@@ -69,8 +68,8 @@ class MonthYearField extends React.Component {
       startYear = predateYear + startYearMod;
     }
 
-    if (this.props.postdate) {
-      const postdate = new Date(this.props.postdate);
+    if (nextProps.postdate) {
+      const postdate = new Date(nextProps.postdate);
       const postdateYear = postdate.getFullYear();
       const postdateMonth = postdate.getMonth();
 
@@ -118,8 +117,6 @@ class MonthYearField extends React.Component {
   }
 
   render() {
-    this.setTimeConstraints();
-
     return (
       <div className="multi-select">
         <SelectField

--- a/app/assets/javascript/app/components/fields/MonthYearField.jsx
+++ b/app/assets/javascript/app/components/fields/MonthYearField.jsx
@@ -37,6 +37,7 @@ class MonthYearField extends React.Component {
   }
 
   setTimeConstraints() {
+    const selectedYear = (this.state.year && this.state.year !== 'NONE') ? parseInt(this.state.year) : null;
     let startMonth = 0;
     let endMonth = monthPool.length;
     let startYear = this.props.startYear || (new Date()).getFullYear();
@@ -46,9 +47,7 @@ class MonthYearField extends React.Component {
       const predate = new Date(this.props.predate);
       const predateYear = predate.getFullYear()
 
-      if (this.state.year && this.state.year !== 'NONE') {
-        const selectedYear = parseInt(this.state.year);
-
+      if (selectedYear) {
         if (predateYear === selectedYear) {
           startMonth = predate.getMonth();
         }
@@ -62,6 +61,19 @@ class MonthYearField extends React.Component {
     }
 
     if (this.props.postdate) {
+      const postdate = new Date(this.props.postdate);
+      const postdateYear = postdate.getFullYear();
+
+      if (selectedYear) {
+        if (postdateYear === selectedYear) {
+          endMonth = postdate.getMonth() + 1;
+        }
+        else if (postdateYear < selectedYear) {
+          this.setState({ year: postdateYear });
+        }
+      }
+
+      range = (postdateYear - startYear) + 1;
     }
 
     this.monthOptions = monthPool.slice(startMonth, endMonth);

--- a/app/assets/javascript/app/components/fields/MonthYearField.jsx
+++ b/app/assets/javascript/app/components/fields/MonthYearField.jsx
@@ -17,6 +17,8 @@ const monthPool = [
   'December',
 ].map((label, value) => ({ label, value }));
 
+const intOrNull = x => (x && x !== 'NONE') ? parseInt(x) : null;
+
 
 class MonthYearField extends React.Component {
 
@@ -36,64 +38,25 @@ class MonthYearField extends React.Component {
   }
 
   componentWillUpdate(nextProps, nextState) {
-    const intOrNull = x => (x && x !== 'NONE') ? parseInt(x) : null;
     const selectedYear = intOrNull(nextState.year);
-    const selectedMonth = intOrNull(nextState.month);
 
-    let startMonth = 0;
-    let endMonth = monthPool.length;
-    let startYear = nextProps.startYear || (new Date()).getFullYear();
-    let range = nextProps.range || 25;
-    let startYearMod = 0;
+    if (selectedYear) {
+      if (nextProps.predate) {
+        const predateYear = (new Date(nextProps.predate)).getFullYear();
 
-    if (nextProps.predate) {
-      const predate = new Date(nextProps.predate);
-      const predateYear = predate.getFullYear()
-      const predateMonth = predate.getMonth();
-
-      if (selectedYear) {
-        if (predateYear === selectedYear) {
-          startMonth = predateMonth;
-        }
-        else if (predateYear > selectedYear) {
+        if (predateYear > selectedYear) {
           this.setState({ year: predateYear });
         }
       }
 
-      if (selectedMonth && predateMonth > selectedMonth) {
-        startYearMod = 1; 
-      }
+      if (nextProps.postdate) {
+        const postdateYear = (new Date(nextProps.postdate)).getFullYear();
 
-      range -= (predateYear - startYear);
-      startYear = predateYear + startYearMod;
-    }
-
-    if (nextProps.postdate) {
-      const postdate = new Date(nextProps.postdate);
-      const postdateYear = postdate.getFullYear();
-      const postdateMonth = postdate.getMonth();
-
-      if (selectedYear) {
-        if (postdateYear === selectedYear) {
-          endMonth = postdate.getMonth() + 1;
-        }
-        else if (postdateYear < selectedYear) {
+        if (postdateYear < selectedYear) {
           this.setState({ year: postdateYear });
         }
       }
-
-      if (selectedMonth && postdateMonth < selectedMonth) {
-        startYearMod = -1;
-      }
-
-      range = (postdateYear - startYear) + 1 + startYearMod;
     }
-
-    this.monthOptions = monthPool.slice(startMonth, endMonth);
-    this.yearOptions = (new Array(range)).fill(null).map((_, i) => ({
-      label: (startYear + i).toString(),
-      value: (startYear + i).toString(),
-    }));
   }
 
   onMonthChange(month) {
@@ -117,19 +80,67 @@ class MonthYearField extends React.Component {
   }
 
   render() {
+    const selectedYear = intOrNull(this.state.year);
+    const selectedMonth = intOrNull(this.state.month);
+
+    let startMonth = 0;
+    let endMonth = monthPool.length;
+    let startYear = this.props.startYear || (new Date()).getFullYear();
+    let range = this.props.range || 25;
+    let startYearMod = 0;
+
+    if (this.props.predate) {
+      const predate = new Date(this.props.predate);
+      const predateYear = predate.getFullYear()
+      const predateMonth = predate.getMonth();
+
+      if (selectedYear && predateYear === selectedYear) {
+        startMonth = predateMonth;
+      }
+
+      if (selectedMonth && predateMonth > selectedMonth) {
+        startYearMod = 1; 
+      }
+
+      range -= (predateYear - startYear);
+      startYear = predateYear + startYearMod;
+    }
+
+    if (this.props.postdate) {
+      const postdate = new Date(this.props.postdate);
+      const postdateYear = postdate.getFullYear();
+      const postdateMonth = postdate.getMonth();
+
+      if (selectedYear && postdateYear === selectedYear) {
+        endMonth = postdate.getMonth() + 1;
+      }
+
+      if (selectedMonth && postdateMonth < selectedMonth) {
+        startYearMod = -1;
+      }
+
+      range = (postdateYear - startYear) + 1 + startYearMod;
+    }
+
+    const monthOptions = monthPool.slice(startMonth, endMonth);
+    const yearOptions = (new Array(range)).fill(null).map((_, i) => ({
+      label: (startYear + i).toString(),
+      value: (startYear + i).toString(),
+    }));
+
     return (
       <div className="multi-select">
         <SelectField
           name={this.props.monthName}
           placeholder={'-- Month --'}
-          options={this.monthOptions}
+          options={monthOptions}
           value={this.state.month}
           onChange={this.onMonthChange}
         />
         <SelectField
           name={this.props.yearName}
           placeholder={'-- Year --'}
-          options={this.yearOptions}
+          options={yearOptions}
           value={this.state.year}
           onChange={this.onYearChange}
         />

--- a/app/assets/javascript/app/components/fields/MonthYearField.jsx
+++ b/app/assets/javascript/app/components/fields/MonthYearField.jsx
@@ -37,32 +37,42 @@ class MonthYearField extends React.Component {
   }
 
   setTimeConstraints() {
-    const selectedYear = (this.state.year && this.state.year !== 'NONE') ? parseInt(this.state.year) : null;
+    const intOrNull = x => (x && x !== 'NONE') ? parseInt(x) : null;
+    const selectedYear = intOrNull(this.state.year);
+    const selectedMonth = intOrNull(this.state.month);
+
     let startMonth = 0;
     let endMonth = monthPool.length;
     let startYear = this.props.startYear || (new Date()).getFullYear();
     let range = this.props.range || 25;
+    let startYearMod = 0;
 
     if (this.props.predate) {
       const predate = new Date(this.props.predate);
       const predateYear = predate.getFullYear()
+      const predateMonth = predate.getMonth();
 
       if (selectedYear) {
         if (predateYear === selectedYear) {
-          startMonth = predate.getMonth();
+          startMonth = predateMonth;
         }
         else if (predateYear > selectedYear) {
           this.setState({ year: predateYear });
         }
       }
 
+      if (selectedMonth && predateMonth > selectedMonth) {
+        startYearMod = 1; 
+      }
+
       range -= (predateYear - startYear);
-      startYear = predateYear;
+      startYear = predateYear + startYearMod;
     }
 
     if (this.props.postdate) {
       const postdate = new Date(this.props.postdate);
       const postdateYear = postdate.getFullYear();
+      const postdateMonth = postdate.getMonth();
 
       if (selectedYear) {
         if (postdateYear === selectedYear) {
@@ -73,7 +83,11 @@ class MonthYearField extends React.Component {
         }
       }
 
-      range = (postdateYear - startYear) + 1;
+      if (selectedMonth && postdateMonth < selectedMonth) {
+        startYearMod = -1;
+      }
+
+      range = (postdateYear - startYear) + 1 + startYearMod;
     }
 
     this.monthOptions = monthPool.slice(startMonth, endMonth);

--- a/app/assets/javascript/app/components/fields/MonthYearField.jsx
+++ b/app/assets/javascript/app/components/fields/MonthYearField.jsx
@@ -5,30 +5,40 @@ import SelectField from './SelectField';
 class MonthYearField extends React.Component {
   constructor(props) {
     super(props);
-    this.monthOptions = [
-      { label: 'January', value: '0' },
-      { label: 'February', value: '1' },
-      { label: 'March', value: '2' },
-      { label: 'April', value: '3' },
-      { label: 'May', value: '4' },
-      { label: 'June', value: '5' },
-      { label: 'July', value: '6' },
-      { label: 'August', value: '7' },
-      { label: 'September', value: '8' },
-      { label: 'October', value: '9' },
-      { label: 'November', value: '10' },
-      { label: 'December', value: '11' },
-    ];
+
+    const monthPool = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ].map((label, value) => ({ label, value }));
+
+    const startMonth = parseInt(this.props.startMonth) || 0;
+    const endMonth = parseInt(this.props.endMonth) || monthPool.length;
+    
+    this.monthOptions = monthPool.slice(startMonth, endMonth);
+
     const startYear = this.props.startYear || (new Date()).getFullYear();
     const range = this.props.range || 25;
+
     this.yearOptions = (new Array(range)).fill(null).map((_, i) => ({
       label: (startYear + i).toString(),
       value: (startYear + i).toString(),
     }));
+
     this.state = {
       month: 'NONE',
       year: 'NONE',
     };
+
     this.onMonthChange = this.onMonthChange.bind(this);
     this.onYearChange = this.onYearChange.bind(this);
   }

--- a/app/assets/javascript/app/components/fields/MonthYearField.jsx
+++ b/app/assets/javascript/app/components/fields/MonthYearField.jsx
@@ -2,45 +2,73 @@ import React from 'react';
 
 import SelectField from './SelectField';
 
+const monthPool = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+].map((label, value) => ({ label, value }));
+
+
 class MonthYearField extends React.Component {
+
   constructor(props) {
     super(props);
-
-    const monthPool = [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December',
-    ].map((label, value) => ({ label, value }));
-
-    const startMonth = parseInt(this.props.startMonth) || 0;
-    const endMonth = parseInt(this.props.endMonth) || monthPool.length;
-    
-    this.monthOptions = monthPool.slice(startMonth, endMonth);
-
-    const startYear = this.props.startYear || (new Date()).getFullYear();
-    const range = this.props.range || 25;
-
-    this.yearOptions = (new Array(range)).fill(null).map((_, i) => ({
-      label: (startYear + i).toString(),
-      value: (startYear + i).toString(),
-    }));
 
     this.state = {
       month: 'NONE',
       year: 'NONE',
     };
 
+    this.monthOptions = monthPool;
+    this.yearOptions = [];
+
     this.onMonthChange = this.onMonthChange.bind(this);
     this.onYearChange = this.onYearChange.bind(this);
+    this.setTimeConstraints = this.setTimeConstraints.bind(this);
+  }
+
+  setTimeConstraints() {
+    let startMonth = 0;
+    let endMonth = monthPool.length;
+    let startYear = this.props.startYear || (new Date()).getFullYear();
+    let range = this.props.range || 25;
+
+    if (this.props.predate) {
+      const predate = new Date(this.props.predate);
+      const predateYear = predate.getFullYear()
+
+      if (this.state.year && this.state.year !== 'NONE') {
+        const selectedYear = parseInt(this.state.year);
+
+        if (predateYear === selectedYear) {
+          startMonth = predate.getMonth();
+        }
+        else if (predateYear > selectedYear) {
+          this.setState({ year: predateYear });
+        }
+      }
+
+      range -= (predateYear - startYear);
+      startYear = predateYear;
+    }
+
+    if (this.props.postdate) {
+    }
+
+    this.monthOptions = monthPool.slice(startMonth, endMonth);
+    this.yearOptions = (new Array(range)).fill(null).map((_, i) => ({
+      label: (startYear + i).toString(),
+      value: (startYear + i).toString(),
+    }));
   }
 
   onMonthChange(month) {
@@ -64,6 +92,8 @@ class MonthYearField extends React.Component {
   }
 
   render() {
+    this.setTimeConstraints();
+
     return (
       <div className="multi-select">
         <SelectField

--- a/app/assets/javascript/app/components/fields/TimeframeField.jsx
+++ b/app/assets/javascript/app/components/fields/TimeframeField.jsx
@@ -14,6 +14,7 @@ class TimeframeField extends React.Component {
         index={index}
       />
     ));
+
     const startDateDisplay = this.props.start
         ? new Date(this.props.start)
             .toLocaleString('en-us', { month: "long", year: 'numeric' })
@@ -22,6 +23,7 @@ class TimeframeField extends React.Component {
         ? new Date(this.props.end)
             .toLocaleString('en-us', { month: "long", year: 'numeric' })
         : 'Unknown Date';
+
     return (
       <div className="timeframe">
         <div className="timeframe-header">
@@ -41,6 +43,7 @@ class TimeframeField extends React.Component {
             <div className="field minor">
               <label htmlFor="start-date">Start Date</label>
               <MonthYearField
+                postdate={this.props.end}
                 monthName="start-date-month"
                 yearName="start-date-year"
                 value={this.props.start}
@@ -51,6 +54,7 @@ class TimeframeField extends React.Component {
             <div className="field minor">
               <label htmlFor="end-date">End Date</label>
               <MonthYearField
+                predate={this.props.start}
                 monthName="end-date-month"
                 yearName="end-date-year"
                 value={this.props.end}


### PR DESCRIPTION
Utilize a predate and/or postdate for MonthYearField components to enforce chronological order between them. The postdate is to set an upper limit on fields while predate is to set a lower limit on fields.