### PR TITLE
Prevent full label overlap

### DIFF
--- a/app/assets/javascript/app/constants/constants.js
+++ b/app/assets/javascript/app/constants/constants.js
@@ -8,6 +8,9 @@ export default {
         FULL: 3,
         HALF: 1,
       },
+      LOCALESTRING_OPTIONS: { month: 'short', year: 'numeric' },
+      // Map labels cannot be within one thousandth lat or lng of another label
+      COLLISION_TOLERANCE: 3,
     },
   },
 };

--- a/app/assets/javascript/app/constants/constants.js
+++ b/app/assets/javascript/app/constants/constants.js
@@ -9,8 +9,9 @@ export default {
         HALF: 1,
       },
       LOCALESTRING_OPTIONS: { month: 'short', year: 'numeric' },
-      // Map labels cannot be within one thousandth lat or lng of another label
-      COLLISION_TOLERANCE: 3,
+      // Map labels cannot be within 0.0005 lat or lng of another label
+      COLLISION_ROUNDING: 0.0005,
+      COLLISION_OFFSET: 0.0001,
     },
   },
 };

--- a/app/assets/javascript/app/util/geojson.js
+++ b/app/assets/javascript/app/util/geojson.js
@@ -8,17 +8,13 @@ export function flatten(arr, depth) {
   }, []);
 };
 
-export function getFirstPoint(geometry) {
-  const coordinates = ((geometry) => {
-    if (geometry.type == 'MultiLineString') {
-      return geometry.coordinates[0][0];
-    }
-    return geometry.coordinates[0];
-  })(geometry);
-  return {
-    type: 'Point',
-    coordinates,
-  };
+export function getMarkerGeometryAndAlternates(nodes) {
+  const midpoint = Math.floor(nodes.length / 2);
+  const markerGeometry = nodes[midpoint].geojson;
+  const others = nodes.slice(0, midpoint)
+      .concat(nodes.slice(midpoint + 1, nodes.length));
+  const alternateMarkerGeometries = others.map((node) => node.geojson);
+  return { markerGeometry, alternateMarkerGeometries };
 };
 
 // Use the GeoJSON in the nodes geometries to assemble a LineString


### PR DESCRIPTION
To test:

1. Create two plans which use the same road segments.
2. Verify that the labels for each road segment are not rendered on the exact same node. They may overlap a little, but you should be able to read the labels if you zoom in enough to separate them.